### PR TITLE
Object Packet Major Refactor

### DIFF
--- a/code/network/multi_obj.h
+++ b/code/network/multi_obj.h
@@ -21,6 +21,7 @@ struct interp_info;
 class object;
 struct header;
 struct net_player;
+class ship;
 
 
 // client button info flags
@@ -36,7 +37,7 @@ struct net_player;
 
 // update info
 typedef struct np_update {	
-	ubyte		seq;							// sequence #
+	ushort		seq;							// sequence #
 	int		update_stamp;				// global update stamp
 	int		status_update_stamp;
 	int		subsys_update_stamp;
@@ -69,6 +70,9 @@ int multi_oo_is_interp_object(object *objp);
 
 // interp
 void multi_oo_interp(object *objp);
+
+// Cyborg17 - sort through subsystems to make sure we only update the ones we need to update.
+//int multi_pack_required_subsytems(ship* shipp, ubyte* data, int packet_size, int header_bytes);
 
 
 // ---------------------------------------------------------------------------------------------------

--- a/code/network/multiutil.cpp
+++ b/code/network/multiutil.cpp
@@ -3626,25 +3626,25 @@ int multi_pack_unpack_vel( int write, ubyte *data, matrix *orient, vec3d * /*pos
 		u = vm_vec_dot( &orient->vec.uvec, &pi->vel );
 		f = vm_vec_dot( &orient->vec.fvec, &pi->vel );
 
-		a = fl2i(r * 0.5f); 
-		b = fl2i(u * 0.5f);
-		c = fl2i(f * 0.5f);
-		CAP(a,-512,511);
-		CAP(b,-512,511);
-		CAP(c,-512,511);
-		bitbuffer_put( &buf, (uint)a, 10 );
-		bitbuffer_put( &buf, (uint)b, 10 );
-		bitbuffer_put( &buf, (uint)c, 10 );
+		a = fl2i(r * 4.0f); 
+		b = fl2i(u * 4.0f);
+		c = fl2i(f * 4.0f);
+		CAP(a,-4096,4095);
+		CAP(b,-4096,4095);
+		CAP(c,-4096,4095);
+		bitbuffer_put( &buf, (uint)a, 13 );
+		bitbuffer_put( &buf, (uint)b, 13 );
+		bitbuffer_put( &buf, (uint)c, 13 );
 
 		return bitbuffer_write_flush(&buf);
 	} else {
 		// unpack velocity
-		a = bitbuffer_get_signed(&buf,10);
-		b = bitbuffer_get_signed(&buf,10);
-		c = bitbuffer_get_signed(&buf,10);
-		r = i2fl(a)/0.5f;
-		u = i2fl(b)/0.5f;
-		f = i2fl(c)/0.5f;
+		a = bitbuffer_get_signed(&buf,13);
+		b = bitbuffer_get_signed(&buf,13);
+		c = bitbuffer_get_signed(&buf,13);
+		r = i2fl(a)/4.0f;
+		u = i2fl(b)/4.0f;
+		f = i2fl(c)/4.0f;
 
 		// Convert into world coordinates
 		vm_vec_zero(&pi->vel);

--- a/code/scripting/api/objs/subsystem.cpp
+++ b/code/scripting/api/objs/subsystem.cpp
@@ -150,6 +150,11 @@ ADE_VIRTVAR(HitpointsLeft, l_Subsystem, "number", "Subsystem hitpoints left", "n
 		//Only go down to 0 hits
 		sso->ss->current_hits = MAX(0.0f, f);
 
+		if(sso->ss->current_hits > 0.0f) {
+			// In multi, need to update clients via object update packet if subsystems are not destroyed
+			maybe_mark_subsystem_for_multi(sso->ss);
+		}
+
 		ship *shipp = &Ships[sso->objp->instance];
 		if (f <= -1.0f && sso->ss->current_hits <= 0.0f) {
 			do_subobj_destroyed_stuff(shipp, sso->ss, NULL);
@@ -175,6 +180,9 @@ ADE_VIRTVAR(HitpointsMax, l_Subsystem, "number", "Subsystem hitpoints max", "num
 		sso->ss->max_hits = MIN(0.0f, f);
 
 		ship_recalc_subsys_strength(&Ships[sso->objp->instance]);
+
+		// Since the max is changing, the strength should be changing, too, so we have to may have to update a client
+		maybe_mark_subsystem_for_multi(sso->ss);
 	}
 
 	return ade_set_args(L, "f", sso->ss->max_hits);

--- a/code/ship/ship.h
+++ b/code/ship/ship.h
@@ -297,6 +297,7 @@ public:
 	char		sub_name[NAME_LENGTH];					//WMC - Name that overrides name of original
 	float		current_hits;							// current number of hits this subsystem has left.
 	float		max_hits;
+	bool		multi_subsytem_is_changed;		// Allows us to mark which subsystems are damaged so that we can just send periodic damage updates instead
 
 	flagset<Ship::Subsystem_Flags> flags;						// Goober5000
 
@@ -1729,6 +1730,8 @@ void armor_init();
 // Sushi - Path metadata
 void init_path_metadata(path_metadata& metadata);
 
+// Cyborg17 - For marking a subsystem's health as changed so that we don't have to add the MULTIPLAYER_MASTER macro everywhere
+void maybe_mark_subsystem_for_multi(ship_subsys *subsys, bool mark = true);
 
 typedef struct ship_effect {
 	char name[NAME_LENGTH];

--- a/code/ship/shiphit.cpp
+++ b/code/ship/shiphit.cpp
@@ -209,6 +209,9 @@ void do_subobj_destroyed_stuff( ship *ship_p, ship_subsys *subsys, vec3d* hitpos
 			hit = g_subobj_pos;
 		}
 		send_subsystem_destroyed_packet( ship_p, index, hit );
+
+		// Cyborg17 - no reason to send subsystem info in the object update, if the destroyed subsystem packet will already take care of it.
+		maybe_mark_subsystem_for_multi(subsys, false);
 	}
 
 	// next do a quick sanity check on the current hits that we are keeping for the generic subsystems
@@ -775,6 +778,11 @@ float do_subobj_hit_stuff(object *ship_objp, object *other_obj, vec3d *hitpos, i
 				damage_to_apply *= ss_dif_scale;
 			}
 
+			// Cyborg17 - Server needs to send subsys strength via object update packet, if not destroyed.
+			if ((damage_to_apply > 0.0f) ){
+				maybe_mark_subsystem_for_multi(subsystem);
+			}
+				
 			subsystem->current_hits -= damage_to_apply;
 			if (!(subsystem->flags[Ship::Subsystem_Flags::No_aggregate])) {
 				ship_p->subsys_info[subsystem->system_info->type].aggregate_current_hits -= damage_to_apply;


### PR DESCRIPTION
Change 1) Reduce Subsystem update overhead:

Allows us to only send subsystems that are required, not everything.
On the whole this should save a lot of bandwidth, allowing us to add a few much needed bits to other parts of the object update packet

I added a flag in all places that subsystems are changed in mission so that the engine would know which to send.

Change 2)  Foward Thrust:

Now actually use the forward thrust we send over the network.  Previously, it was sent, read, and then ignored.

Change 3) - Add Side Thrust:

Include side thrust!  Now those Mara's and Dragons should be where you expect. At the cost of only one more byte per packet. (if position is flagged, like it almost always is)

Change 4) - Change Order For Vel Calc:

Change positions of veloctiy and orientation in the packet so that correct orienation can take part in retreiving the correct velocity from compression within the packet.

Change 5) - Increase velocity accuracy
Decrease the compression of velocity in the packet. Uses only one more byte but should allow the velocity to be calculated to be within .5 m/s of the server velocity instead of 3 m/s.

Change 6) - Increase size of Sequence Number by One Byte

Add a byte to the object update sequence number (change it from a ubyte to a ushort). This should make object updating smoother since wrapping the 16 bit sequence number is much, much rarer